### PR TITLE
Add two commandline arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,56 @@
 # VF-1
 Command line gopher client.  High speed, low drag.
 
+## Invocation
+
+Start VF-1:
+
+```
+vf1
+```
+
+Start VF-1 with your bookmarks:
+
+```
+vf1 --bookmarks
+```
+
+Start VF-1 with your favorite site:
+
+```
+vf1 --go phlogosphere.org
+```
+
+## Installing
+
+Ideally, you would install VF-1 as follows:
+
+```
+pip3 install VF-1
+```
+
+This should install the command `vf1` in either `/usr/local/bin`,
+`/usr/bin`, or `~/.local/bin`.
+
+Alternatively, check out the source code and install it as follows:
+
+```
+pip3 install .
+```
+
+If you're a developer, you probably want an "editable" installation:
+
+```
+pip3 install --editable .
+```
+
+If you're a developer on a Windows machine and your pip is broken, you
+can also install as follows:
+
+```
+python3 setup.py install
+```
+
 ## Quick, informal tutorial-style introduction
 
 VF-1 is built around an interactive command prompt, and has a very "REPL"

--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ can also install as follows:
 python3 setup.py install
 ```
 
+And finally, if you just can't install it, just copy the `vf1/vf1.py`
+file and run it directly.
+
+```
+python3 vf1/vf1.py
+```
+
 ## Quick, informal tutorial-style introduction
 
 VF-1 is built around an interactive command prompt, and has a very "REPL"

--- a/vf1/__init__.py
+++ b/vf1/__init__.py
@@ -1,8 +1,21 @@
+import argparse
 from . import vf1
 
+
+
 def main():
-    # eventually we can add command line parsing here
+    parser = argparse.ArgumentParser(description='A command line gopher client.')
+    parser.add_argument('--bookmarks', action='store_true',
+                        help='start with your list of bookmarks')
+    parser.add_argument('--go', metavar='URL', nargs=1,
+                        help='start with this URL')
+    args = parser.parse_args()
+
     gc = vf1.GopherClient()
+    if args.bookmarks:
+        gc.do_bookmarks()
+    elif args.go:
+        gc.do_go(args.go[0])
     gc.cmdloop()
     
 if __name__ == "__main__":


### PR DESCRIPTION
If you know a way to get rid of `--go`, that would be great.