### PR TITLE
Install a handler for SIGINT

### DIFF
--- a/vf1/vf1.py
+++ b/vf1/vf1.py
@@ -13,6 +13,12 @@ import sys
 import tempfile
 import traceback
 import urllib.parse
+import signal
+
+def signal_handler(signal, frame):
+    print("BREAK")
+
+signal.signal(signal.SIGINT, signal_handler)
 
 # Command abbreviations
 _ABBREVS = {


### PR DESCRIPTION
Possibly a fix for #5 

This should prevent a keyboard interrupt traceback being shown to the
user when they hit Ctrl-C.

Perhaps printing in the signal handler is tricky. I couldn't reproduce
the two or three error messages I got.
https://stackoverflow.com/questions/45680378/how-to-explain-the-reentrant-runtimeerror-caused-by-printing-in-signal-handlers

I've tried the object.__exit__ and the atexit solutions and they
didn't get me very far.
https://stackoverflow.com/questions/4205317/capture-keyboardinterrupt-in-python-without-try-except#4205386

I don't know how to get back to the command loop. Perhaps there is no
way to do it due to reentry issues.
https://stackoverflow.com/questions/4604634/which-functions-are-re-entrant-in-python-for-signal-library-processing