### PR TITLE
Catch OSError, too

### DIFF
--- a/vf1.py
+++ b/vf1.py
@@ -164,6 +164,10 @@ class GopherClient(cmd.Cmd):
             if not self.tls:
                 print("Switch to battloid mode using 'tls' to enable encryption.")
             return
+        except OSError:
+            print("ERROR: Operating system error... Recovery initiated...")
+            print("Consider toggling battloid mode using 'tls' to adapt to the new situation.")
+            return
         except ssl.SSLError as err:
             print("ERROR: " + err.reason)
             if err.reason == "UNKNOWN_PROTOCOL":


### PR DESCRIPTION
On this other laptop, connecting to a site with no TSL support but
VF-1 in battloid mode gives me a new error... The list of errors is
amazingly wide. Not sure if OSError includes any interesting
information. The backtrace shows that the error happens during
handshake, so I just mention the tls command in the reply. Better than
crashing.