### PR TITLE
Fix handling of file links in bookmarks

### DIFF
--- a/vf1.py
+++ b/vf1.py
@@ -178,7 +178,7 @@ class GopherClient(cmd.Cmd):
         # Hit the network
         try:
             # Is this a local file?
-            if gi.host is None:
+            if not gi.host:
                 f = open(gi.path, "rb")
             # Is this a search point?
             elif gi.itemtype == "7":


### PR DESCRIPTION
When getting a file link from bookmarks, host is not None but the
empty string.