### PR TITLE
Allow items in maps without hostname and port

### DIFF
--- a/vf1.py
+++ b/vf1.py
@@ -128,8 +128,8 @@ def gopheritem_to_url(gi):
         return ""
 
 def gopheritem_from_line(line, tls):
-    line = line.strip()
     name, path, server, port = line.split("\t")
+    port = port.strip()
     itemtype = name[0]
     name = name[1:]
     return GopherItem(server, port, path, itemtype, name, tls)


### PR DESCRIPTION
When adding local file items to bookmarks, we want to not use a
hostname or port. If we strip the line before splitting, those
trailing tab characters are removed. Thus we turn it around: split
first and then just strip the last item, the port.