### PR TITLE
Use shlex.split to find the name of the handler

### DIFF
--- a/vf1.py
+++ b/vf1.py
@@ -266,7 +266,7 @@ class GopherClient(cmd.Cmd):
             try:
                 subprocess.call(shlex.split(cmd_str % tmpf.name))
             except FileNotFoundError:
-                print("Handler program %s not found!" % cmd_str.split()[0])
+                print("Handler program %s not found!" % shlex.split(cmd_str)[0])
                 print("You can use the ! command to specify another handler program or pipeline.")
 
         # Update state


### PR DESCRIPTION
In the error message, we should not use cmd_str.split()[0] to find the
name of the handler because that breaks if the handler contains
whitespace (and quotes, of course). Better to use
shlex.split(cmd_str)[0] instead, which does the right thing.