### PR TITLE
add IPv6 support

### DIFF
--- a/vf1.py
+++ b/vf1.py
@@ -995,7 +995,8 @@ Returns a binary file with the reply."""
         port = DEF_PORT
     elif type(port) == type(''):
         port = int(port)
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    addrinfo = socket.getaddrinfo(host, port, type=1)
+    s = socket.socket(addrinfo[0][0], socket.SOCK_STREAM)
     if tls:
         context = ssl.create_default_context()
         # context.check_hostname = False


### PR DESCRIPTION
Support IPv6 connections. No idea if this is the best way to do it, I tried using setsockopts but it didn't seem to be what I wanted, if this isn't up to snuff I hope it inspires better IPv6 support.
Working on a darknet project with some friends which only supports IPv6 and wanted to use VF-1 to browse gopherholes we set up.